### PR TITLE
Added configurable instance monitoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: scala
 scala:
-  - 2.10.3
+  - 2.10.4
 env:
   global:
     - secure: "NkBORJGyKKoGv7sOEifM1v8reMoumsN8HaU5lWv/Gg00uxjpGyoNupl0CIEIlxC+f6f4Twv9oIiKtJriaMuKtyJOVX3fBX7JrXmxmXqZr3NVR/LNmh3Qzu5cyc6kd5goaXZjS6EBMqGuz5dObd1qPKLgvXXA8A4IlARwVKqXqMo="
     - secure: "bVHdBlIN1M6bZpsd8UK/h0yfHvHNbR7E6nM22O22UYRtfyh23UlHSKpV42MRR6bdUZjweEhXO/wTEilfOXo/3qbDc+bpo6JBwHNF8eYEC6dxqKqVCKohL9+j9VUpezNznwMcNSEvYvSyYAsjRAMIl9t8Y2nPaS3dWfpAkFFT5zU="
 script:
-  - "sbt publish"
+  - "sbt package"
 jdk:
   - oraclejdk7

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,10 @@ organization := "ohnosequences"
 
 bucketSuffix := "era7.com"
 
+scalaVersion := "2.10.4"
+
+crossScalaVersions := Seq("2.11.4")
+
 libraryDependencies ++= Seq(
 //  "com.amazonaws" % "aws-java-sns" % "1.9.8",
 //  "com.amazonaws" % "aws-java-sqs" % "1.9.8",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,3 @@
-resolvers ++= Seq(
-  "Era7 Releases"       at "http://releases.era7.com.s3.amazonaws.com",
-  "Era7 Snapshots"      at "http://snapshots.era7.com.s3.amazonaws.com"
-)
+resolvers += "Era7 Releases" at "http://releases.era7.com.s3.amazonaws.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.4.0-RC3")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.5.0-RC1")

--- a/src/main/scala/ohnosequences/awstools/autoscaling/AutoScaling.scala
+++ b/src/main/scala/ohnosequences/awstools/autoscaling/AutoScaling.scala
@@ -43,6 +43,7 @@ class AutoScaling(val as: AmazonAutoScaling, ec2: ohnosequences.awstools.ec2.EC2
         .withUserData(Utils.base64encode(launchConfiguration.instanceSpecs.userData))
         .withKeyName(launchConfiguration.instanceSpecs.keyName)
         .withSecurityGroups(launchConfiguration.instanceSpecs.securityGroups)
+        .withInstanceMonitoring(new InstanceMonitoring().withEnabled(launchConfiguration.instanceSpecs.instanceMonitoring))
         .withBlockDeviceMappings(
         launchConfiguration.instanceSpecs.deviceMapping.map{ case (key, value) =>
           new BlockDeviceMapping().withDeviceName(key).withVirtualName(value)

--- a/src/main/scala/ohnosequences/awstools/autoscaling/AutoScalingGroup.scala
+++ b/src/main/scala/ohnosequences/awstools/autoscaling/AutoScalingGroup.scala
@@ -53,7 +53,8 @@ object LaunchConfiguration {
         securityGroups = launchConfiguration.getSecurityGroups.toList,
         deviceMapping = launchConfiguration.getBlockDeviceMappings.map(m => (m.getDeviceName, m.getVirtualName)).toMap,
         userData = launchConfiguration.getUserData,
-        instanceProfile =  Utils.stringToOption(launchConfiguration.getIamInstanceProfile)
+        instanceProfile =  Utils.stringToOption(launchConfiguration.getIamInstanceProfile),
+        instanceMonitoring = launchConfiguration.getInstanceMonitoring.isEnabled
       )
     )
   }

--- a/src/main/scala/ohnosequences/awstools/ec2/EC2.scala
+++ b/src/main/scala/ohnosequences/awstools/ec2/EC2.scala
@@ -25,6 +25,7 @@ object InstanceSpecs {
       .withInstanceType(specs.instanceType)
       .withImageId(specs.amiId)
       .withKeyName(specs.keyName)
+      .withMonitoringEnabled(specs.instanceMonitoring)
       .withBlockDeviceMappings(specs.deviceMapping.map{ case (key, value) =>
         new BlockDeviceMapping()
           .withDeviceName(key)
@@ -55,6 +56,7 @@ case class InstanceSpecs(instanceType: awstools.InstanceType,
                          userData: String = "",
                          instanceProfile: Option[String] = None,
                          securityGroups: List[String] = List(),
+                         instanceMonitoring: Boolean = false,
                          deviceMapping: Map[String, String] = Map[String, String]())
 
 


### PR DESCRIPTION
Added instance monitoring parameter to InstanceSpecs (with default `false`). It's a bit strange though, that for autoscaling group `LaunchConfiguration` you use `InstanceSpecs` from ec2 (in aws-java-sdk they are different), but I guess it's for good.