### PR TITLE
Improve availability zones handling in autoscaling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,10 @@ description := "AWS Scala tools"
 
 bucketSuffix := "era7.com"
 scalaVersion := "2.11.7"
-crossScalaVersions := Seq("2.10.5", scalaVersion.value)
+crossScalaVersions := Seq(scalaVersion.value, "2.10.6")
 
 
-val sdkVersion = "1.10.37"
+val sdkVersion = "1.10.39"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sns"         % sdkVersion,

--- a/notes/0.16.0.markdown
+++ b/notes/0.16.0.markdown
@@ -1,0 +1,7 @@
+This release introduces a non-breaking improvement/fix:
+
+* Updated aws java sdk from `v1.9.37` to `v1.10.39`
+* When creating an autoscaling group, you have to set a list of availability zones:
+    - the default was set to `List("eu-west-1a", "eu-west-1b", "eu-west-1c"})`, now it's an _empty list_
+    - in the autoscaling client a `getAllAvailableZones(): List[String]` method is added
+    - on creation of a new AS group the list of preferred zones is checked and if it's empty, all available zones are retrieved and used in the request

--- a/src/main/scala/ohnosequences/awstools/autoscaling/AutoScalingGroup.scala
+++ b/src/main/scala/ohnosequences/awstools/autoscaling/AutoScalingGroup.scala
@@ -15,8 +15,7 @@ case class AutoScalingGroup(
   val launchConfiguration: LaunchConfiguration,
   val name: String,
   val size: AutoScalingGroupSize,
-  // FIXME: this shouldn't be so explicit:
-  val availabilityZones: List[String] = List("eu-west-1a", "eu-west-1b", "eu-west-1c")
+  val availabilityZones: List[String] = List()
 )
 
 case object AutoScalingGroup {

--- a/src/main/scala/ohnosequences/awstools/ec2/InstanceType.scala
+++ b/src/main/scala/ohnosequences/awstools/ec2/InstanceType.scala
@@ -28,13 +28,6 @@ sealed class InstanceType[
 }
 
 case object InstanceType {
-  implicit class it(private val sc: StringContext) extends AnyVal {
-    def foo(args: Int*): String = {
-      sc.parts.zip(args :+ 0).foldLeft(""){ case (acc, (part, arg)) =>
-        s"${part}${arg+1}${acc}"
-      }
-    }
-  }
 
   @deprecated("Use conversion from an arbitrary String carefully", since = "v0.6.0")
   private[awstools]


### PR DESCRIPTION
This is a non-breaking improvement/fix. When creating an autoscaling group, you have to set a list of availability zones:
- the default was set to `List(eu-west-1{a, b, c})`, now it's an empty list
- in the autoscaling client a `getAllAvailableZones` method is added
- when creating a new group, now it checks if the list of preferred zones is empty, all available zones are retrieved and used in the request