### PR TITLE
Update aws-sdk-java dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ## AWS Scala tools
 
-[![Build Status](https://travis-ci.org/ohnosequences/aws-scala-tools.svg?branch=master)](https://travis-ci.org/ohnosequences/aws-scala-tools)
-[![Codacy Badge](https://api.codacy.com/project/badge/grade/441155fcef304bbdb7054dbde04ec172)](https://www.codacy.com/app/laughedelic/aws-scala-tools)
-[![Latest release](https://img.shields.io/github/release/ohnosequences/aws-scala-tools.svg)](https://github.com/ohnosequences/aws-scala-tools/releases/latest)
-[![License](https://img.shields.io/badge/license-AGPLv3-blue.svg)](https://tldrlegal.com/license/gnu-affero-general-public-license-v3-%28agpl-3.0%29)
-[![Gitter](https://img.shields.io/badge/contact-gitter_chat-dd1054.svg)](https://gitter.im/ohnosequences/aws-scala-tools)
+[![](https://travis-ci.org/ohnosequences/aws-scala-tools.svg?branch=master)](https://travis-ci.org/ohnosequences/aws-scala-tools)
+[![](https://img.shields.io/codacy/441155fcef304bbdb7054dbde04ec172.svg)](https://www.codacy.com/app/era7/aws-scala-tools)
+[![](https://img.shields.io/github/release/ohnosequences/aws-scala-tools.svg)](https://github.com/ohnosequences/aws-scala-tools/releases/latest)
+[![](https://img.shields.io/badge/license-AGPLv3-blue.svg)](https://tldrlegal.com/license/gnu-affero-general-public-license-v3-%28agpl-3.0%29)
+[![](https://img.shields.io/badge/contact-gitter_chat-dd1054.svg)](https://gitter.im/ohnosequences/aws-scala-tools)
 
 
-A Scala wrapper for AWS Java SDK:
+A Scala wrapper for [AWS Java SDK](https://github.com/aws/aws-sdk-java):
 
 * EC2 + some AutoScaling
 * S3

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.11.7"
 crossScalaVersions := Seq(scalaVersion.value, "2.10.6")
 
 
-val sdkVersion = "1.10.39"
+val sdkVersion = "1.10.54"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sns"         % sdkVersion,
@@ -19,8 +19,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3"          % sdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2"         % sdkVersion,
   "com.amazonaws" % "aws-java-sdk-iam"         % sdkVersion,
-  "org.scalatest" %% "scalatest"               % "2.2.5"     % Test
+  "org.scalatest" %% "scalatest"               % "2.2.6"     % Test
 )
 
-// FIXME: warts should be turn on back after the code clean up
+// FIXME: warts should be turned on back after the code is cleaned up
 wartremoverErrors in (Compile, compile) := Seq()


### PR DESCRIPTION
There are new [releases](https://github.com/aws/aws-sdk-java/releases) every week or even more often. I'm going to update this dep. Unfortunately, there are no release notes, but I guess, minor updates are safe.