### PR TITLE
S3: copy folders

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,3 +30,5 @@ wartremoverWarnings in (Compile, compile) --= Seq(
 wartremoverErrors in (Test, compile) --= Seq(
   Wart.TryPartial
 )
+
+parallelExecution in Test := false

--- a/src/main/scala/ohnosequences/awstools/s3/client.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/client.scala
@@ -17,7 +17,7 @@ case class ScalaS3Client(val asJava: AmazonS3) extends AnyVal { s3 =>
       .withS3Client(s3.asJava)
       .build()
 
-  def transfer[T](action: TransferManager => T): T = {
+  def withTransferManager[T](action: TransferManager => T): T = {
     val tm = createTransferManager
     val result = action(tm)
     tm.shutdownNow(false)

--- a/src/main/scala/ohnosequences/awstools/s3/client.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/client.scala
@@ -8,6 +8,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 import java.net.URL
+import java.io.File
 
 
 case class ScalaS3Client(val asJava: AmazonS3) extends AnyVal { s3 =>
@@ -22,6 +23,34 @@ case class ScalaS3Client(val asJava: AmazonS3) extends AnyVal { s3 =>
     val result = action(tm)
     tm.shutdownNow(false)
     result
+  }
+
+  def download(
+    src: AnyS3Address,
+    dst: File
+  ): Try[File] = withTransferManager {
+    _.download(src, dst)
+  }
+
+  def upload(
+    src: File,
+    dst: AnyS3Address
+  ): Try[AnyS3Address] = withTransferManager {
+    _.upload(src, dst)
+  }
+
+  def copy(
+    src: S3Object,
+    dst: S3Object
+  ): Try[S3Object] = withTransferManager {
+    _.copy(src, dst)
+  }
+
+  def copy(
+    src: S3Folder,
+    dst: S3Folder
+  ): Try[List[S3Object]] = withTransferManager {
+    _.copy(src, dst)
   }
 
   def waitUntil: AmazonS3Waiters = s3.asJava.waiters

--- a/src/main/scala/ohnosequences/awstools/s3/client.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/client.scala
@@ -17,6 +17,13 @@ case class ScalaS3Client(val asJava: AmazonS3) extends AnyVal { s3 =>
       .withS3Client(s3.asJava)
       .build()
 
+  def transfer[T](action: TransferManager => T): T = {
+    val tm = createTransferManager
+    val result = action(tm)
+    tm.shutdownNow(false)
+    result
+  }
+
   def waitUntil: AmazonS3Waiters = s3.asJava.waiters
 
   // TODO: rewrite using rotateTokens and listObjectsV2 method

--- a/src/main/scala/ohnosequences/awstools/s3/package.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/package.scala
@@ -40,7 +40,7 @@ package object s3 {
     ScalaS3Client =
     ScalaS3Client(s3)
 
-  implicit def transferManagerOps(tm: TransferManager):
-    TransferManagerOps =
-    TransferManagerOps(tm)
+  implicit def toScalaTransferManager(tm: TransferManager):
+    ScalaTransferManager =
+    ScalaTransferManager(tm)
 }

--- a/src/main/scala/ohnosequences/awstools/s3/transfers.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/transfers.scala
@@ -106,6 +106,20 @@ case class TransferManagerOps(asJava: TransferManager) { tm =>
   }
 
   def copy(
+    source:      S3Object,
+    destination: S3Object
+  ): Try[S3Object] = {
+    Try {
+      tm.asJava.copy(
+        source.bucket, source.key,
+        destination.bucket, destination.key
+      ).waitForCompletion
+
+      destination
+    }
+  }
+
+  def copy(
     source:      S3Folder,
     destination: S3Folder
   ): Try[List[S3Object]] = {

--- a/src/main/scala/ohnosequences/awstools/s3/transfers.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/transfers.scala
@@ -36,7 +36,7 @@ case class s3MetadataProvider(metadataMap: Map[String, String]) extends ObjectMe
 }
 
 
-case class TransferManagerOps(asJava: TransferManager) { tm =>
+case class ScalaTransferManager(asJava: TransferManager) { tm =>
 
   // by default shutdownNow shuts down the S3 client as well
   def shutdown(shutDownS3Client: Boolean = false): Unit =

--- a/src/test/scala/ohnosequences/awstools/s3.scala
+++ b/src/test/scala/ohnosequences/awstools/s3.scala
@@ -1,0 +1,100 @@
+package ohnosequences.awstools.test
+
+import com.amazonaws.services.s3.AmazonS3
+import ohnosequences.awstools._, s3._
+// import scala.util.{ Try, Success, Failure, Random }
+import java.io.File
+import java.nio.file._
+import scala.collection.JavaConverters._
+
+case class tmpFiles(prefix: File) {
+  val f1 = new File(prefix, "f1")
+  val f2 = new File(prefix, "foo/f2")
+
+  val files = List(f1, f2)
+
+  def write(file: File) = {
+    val parent = file.getParentFile
+    if (!parent.exists) Files.createDirectories(parent.toPath)
+    Files.write(file.toPath, List(file.getName).asJava)
+  }
+
+  def writeFiles() = files.foreach(write)
+}
+
+class S3 extends org.scalatest.FunSuite with org.scalatest.BeforeAndAfterAll {
+
+  lazy val s3Client: AmazonS3 = s3.defaultClient
+
+  lazy val s3prefix = s3"aws-scala-tools-testing" / "s3" /
+
+  lazy val srcS3 = s3prefix / "test1" /
+  lazy val dstS3 = s3prefix / "test2" /
+
+  lazy val tmp = tmpFiles(
+    Files.createTempDirectory(Paths.get("target"), "s3-testing").toFile
+  )
+
+  override def beforeAll() = {
+    if (!s3Client.doesBucketExistV2(s3prefix.bucket))
+      s3Client.createBucket(s3prefix.bucket)
+
+    tmp.writeFiles()
+  }
+
+  override def afterAll() = {
+    // s3Client.deleteBucket(s3prefix.bucket)
+    s3Client.listObjects(s3prefix).foreach { list =>
+      list.foreach { obj =>
+        s3Client.deleteObject(obj.bucket, obj.key)
+      }
+    }
+  }
+
+
+  test(s"Uploading to ${srcS3}") {
+    val uploadTry = s3Client.transfer { _.upload(tmp.prefix, srcS3) }
+    assert { uploadTry.isSuccess }
+
+    uploadTry.foreach { dst =>
+      info(s"Uploaded [${tmp.prefix}] to [${srcS3}]")
+    }
+  }
+
+  test(s"Copying one ${srcS3} to ${dstS3}") {
+    val copyTry = s3Client.transfer { _.copy(srcS3, dstS3) }
+    assert { copyTry.isSuccess }
+
+    copyTry.foreach { list =>
+      list.foreach { obj =>
+        info(s"Copied object ${obj.toString}")
+      }
+    }
+  }
+
+  test(s"Downloading from ${dstS3}") {
+    val dst = Files.createTempDirectory(Paths.get("target"), "s3-testing").toFile
+
+    val downloadTry = s3Client.transfer { _.download(dstS3, dst) }
+    assert { downloadTry.isSuccess }
+
+    downloadTry.foreach { file =>
+      info(s"Downloaded [${dstS3}] to [${file}]")
+
+      val dstTmp = tmpFiles(file)
+
+      assert { dstTmp.f1.exists }
+      assert { dstTmp.f2.exists }
+
+      // Checking that the content if the same as we uploaded:
+      assert {
+        Files.readAllLines(tmp.f1.toPath) ==
+        Files.readAllLines(dstTmp.f1.toPath)
+      }
+      assert {
+        Files.readAllLines(tmp.f2.toPath) ==
+        Files.readAllLines(dstTmp.f2.toPath)
+      }
+    }
+  }
+}

--- a/src/test/scala/ohnosequences/awstools/s3.scala
+++ b/src/test/scala/ohnosequences/awstools/s3.scala
@@ -54,9 +54,7 @@ class S3 extends org.scalatest.FunSuite with org.scalatest.BeforeAndAfterAll {
 
 
   test(s"Uploading to ${srcS3}") {
-    val uploadTry = s3Client.withTransferManager {
-      _.upload(tmp.prefix, srcS3)
-    }
+    val uploadTry = s3Client.upload(tmp.prefix, srcS3)
     assert { uploadTry.isSuccess }
 
     uploadTry.foreach { dst =>
@@ -65,9 +63,7 @@ class S3 extends org.scalatest.FunSuite with org.scalatest.BeforeAndAfterAll {
   }
 
   test(s"Copying one ${srcS3} to ${dstS3}") {
-    val copyTry = s3Client.withTransferManager {
-      _.copy(srcS3, dstS3)
-    }
+    val copyTry = s3Client.copy(srcS3, dstS3)
     assert { copyTry.isSuccess }
 
     copyTry.foreach { list =>
@@ -94,9 +90,7 @@ class S3 extends org.scalatest.FunSuite with org.scalatest.BeforeAndAfterAll {
   test(s"Downloading from ${dstS3}") {
     val dst = Files.createTempDirectory(Paths.get("target"), "s3-testing").toFile
 
-    val downloadTry = s3Client.withTransferManager {
-      _.download(dstS3, dst)
-    }
+    val downloadTry = s3Client.download(dstS3, dst)
     assert { downloadTry.isSuccess }
 
     downloadTry.foreach { file =>


### PR DESCRIPTION
Add `copy` for the transfer manager ops that works both for objects and for folder
 (doesn't exist in the java-sdk)
