### PR TITLE
Downloading an existing file results in 404

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ description := "AWS Scala tools"
 
 bucketSuffix := "era7.com"
 
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+crossScalaVersions := Seq("2.11.12", "2.12.4")
 scalaVersion := crossScalaVersions.value.max
 
 // https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.1.0

--- a/src/main/scala/ohnosequences/awstools/s3/address.scala
+++ b/src/main/scala/ohnosequences/awstools/s3/address.scala
@@ -28,7 +28,7 @@ sealed trait AnyS3Address {
 }
 
 
-case class S3Folder(b: String, k: String) extends AnyS3Address {
+class S3Folder private(b: String, k: String) extends AnyS3Address {
   val _bucket = b
   // NOTE: we explicitly add / in the end here (it represents the empty S3 object of the folder)
   val _key = k + "/"
@@ -37,7 +37,11 @@ case class S3Folder(b: String, k: String) extends AnyS3Address {
 }
 
 object S3Folder {
+  // NOTE: This returns sanitized key in contrast with the case class default unapply method
+  def unapply(addr: S3Folder): Option[(String, String)] =
+    Some((addr.bucket, addr.key))
 
+  def apply(b: String, k: String): S3Folder = new S3Folder(b, k)
   def apply(uri: URI): S3Folder = S3Folder(uri.getHost, uri.getPath)
 
   def toS3Object(f: S3Folder): S3Object =
@@ -45,7 +49,7 @@ object S3Folder {
 }
 
 
-case class S3Object(_bucket: String, _key: String) extends AnyS3Address {
+class S3Object private(val _bucket: String, val _key: String) extends AnyS3Address {
 
   def /(): S3Folder = S3Folder(bucket, key)
 
@@ -53,8 +57,12 @@ case class S3Object(_bucket: String, _key: String) extends AnyS3Address {
 }
 
 object S3Object {
+  // NOTE: This returns sanitized key in contrast with the case class default unapply method
+  def unapply(addr: S3Object): Option[(String, String)] =
+    Some((addr.bucket, addr.key))
 
-  def apply(uri: URI): S3Object = S3Object(uri.getHost, uri.getPath)
+  def apply(b: String, k: String): S3Object = new S3Object(b, k)
+  def apply(uri: URI): S3Object = apply(uri.getHost, uri.getPath)
 }
 
 

--- a/src/test/scala/ohnosequences/awstools/s3.scala
+++ b/src/test/scala/ohnosequences/awstools/s3.scala
@@ -52,6 +52,48 @@ class S3 extends org.scalatest.FunSuite with org.scalatest.BeforeAndAfterAll {
     }
   }
 
+  test("S3 addresses are (de)constructed correctly") {
+
+    val obj = s3"bucket" / "foo//bar" / "/buh"
+
+    assertResult(Set("s3://bucket/foo/bar/buh")) {
+      Set(
+        obj.toURI.toString,
+        obj.toString,
+        obj.url
+      )
+    }
+
+    assertResult("bucket") { obj.bucket }
+    assertResult("foo/bar/buh") { obj.key }
+
+    obj match {
+      case S3Object(bucket, key) => {
+        assertResult("bucket") { bucket }
+        assertResult("foo/bar/buh") { key }
+      }
+    }
+
+    val fldr = obj /
+
+    assertResult(Set("s3://bucket/foo/bar/buh/")) {
+      Set(
+        fldr.toURI.toString,
+        fldr.toString,
+        fldr.url
+      )
+    }
+
+    assertResult("bucket") { fldr.bucket }
+    assertResult("foo/bar/buh/") { fldr.key }
+
+    fldr match {
+      case S3Folder(bucket, key) => {
+        assertResult("bucket") { bucket }
+        assertResult("foo/bar/buh/") { key }
+      }
+    }
+  }
 
   test(s"Uploading to ${srcS3}") {
     val uploadTry = s3Client.upload(tmp.prefix, srcS3)


### PR DESCRIPTION
Ping @agarciamontoro for details. I almost forgot about it 😅 

As far as I remember, there was a file on S3 which couldn't be downloaded using this lib (from Loquat) returning `AmazonS3Exception: Not Found (Service: Amazon S3; Status Code: 404;)`, but worked fine with the AWS Java SDK (or AWS CLI). It definitely wasn't a problem with access permissions.

The version used there, if I recall correctly, was 0.19.? 

I need to reproduce it first with some other file and find out what's wrong with the `ScalaTransferManager.download` method.